### PR TITLE
Returns err on closing

### DIFF
--- a/error.go
+++ b/error.go
@@ -15,3 +15,8 @@ type UnknownIDError struct {
 func (e UnknownIDError) Error() string {
 	return "id " + strconv.FormatUint(e.ID, 10) + " is unknown in the topic. Lowest id is " + strconv.FormatUint(e.FirstID, 10)
 }
+
+type closingError struct{}
+
+func (e closingError) Error() string { return "topic was closed" }
+func (e closingError) Closing()      {}

--- a/example_test.go
+++ b/example_test.go
@@ -2,6 +2,7 @@ package topic_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/ostcar/topic"
@@ -25,14 +26,19 @@ func ExampleTopic() {
 	for {
 		id, values, err = top.Receive(context.Background(), id)
 		if err != nil {
+			var closing interface {
+				Closing()
+			}
+			if errors.As(err, &closing) {
+				// topic was closed
+				return
+			}
+
 			// Handle Error:
-			fmt.Printf("Receive() returned an unexpected error %v", err)
+			fmt.Printf("Receive() returned an unexpected error: %v", err)
 			return
 		}
-		if len(values) == 0 {
-			// When no values are returned, the topic is closed.
-			return
-		}
+
 		// Process values:
 		for _, v := range values {
 			fmt.Println(v)


### PR DESCRIPTION
When the context is closed, return context.Canceled.
When the topic is closed, return err with method Closing()