### PR TITLE
Split topic.Receive to topic.ReceiveAll and topic.ReceiveSince.

### DIFF
--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -18,7 +18,7 @@ func benchmarkPublishWithXReceivers(count int, b *testing.B) {
 			var id uint64
 			var values []string
 			for {
-				id, values, _ = top.Receive(ctx, id)
+				id, values, _ = top.ReceiveSince(ctx, id)
 				if len(values) == 0 {
 					return
 				}
@@ -47,7 +47,7 @@ func benchmarkRetrieveBigTopic(count int, b *testing.B) {
 	b.ResetTimer()
 
 	for b.Loop() {
-		top.Receive(b.Context(), 0)
+		top.ReceiveSince(b.Context(), 0)
 	}
 }
 
@@ -69,7 +69,7 @@ func benchmarkRetrieveLastBigTopic(count int, b *testing.B) {
 	b.ResetTimer()
 
 	for b.Loop() {
-		top.Receive(ctx, id-1)
+		top.ReceiveSince(ctx, id-1)
 	}
 }
 

--- a/example_test.go
+++ b/example_test.go
@@ -24,7 +24,7 @@ func ExampleTopic() {
 	var values []string
 	var err error
 	for {
-		id, values, err = top.Receive(ctx, id)
+		id, values, err = top.ReceiveSince(ctx, id)
 		if err != nil {
 			if errors.Is(err, context.Canceled) {
 				// shutdown was called.


### PR DESCRIPTION
In the old system, ReceiveAll was implemented by giviing an `0`-id to Receive. This was vague.

The new system uses different function to make it more clear.